### PR TITLE
CI: Use goreleaser to build release artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,19 +66,9 @@ jobs:
     uses: heathcliff26/ci/.github/workflows/golang-build.yaml@main
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: linux
-            arch: amd64
-          - os: linux
-            arch: arm64
     with:
       release: "${{ github.event_name == 'pull_request' && 'devel' || inputs.tag == '' && 'rolling' || inputs.tag }}"
-      goos: "${{ matrix.os }}"
-      goarch: "${{ matrix.arch }}"
-      artifact: "bin/pinentry-keyring-${{ matrix.os }}-${{ matrix.arch }}*"
-      artifact-name: "pinentry-keyring-${{ matrix.os }}-${{ matrix.arch }}"
-      cmd: "hack/build.sh pinentry-keyring-${{ matrix.os }}-${{ matrix.arch }}"
+      artifact: "dist/pinentry-keyring*"
+      artifact-name: "pinentry-keyring"
+      cmd: "make release"
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
       update: ${{ inputs.update }}
       tag: ${{ inputs.tag }}
       release-artifacts: "release/*"
-      artifacts: "pinentry-keyring-*"
+      artifacts: "pinentry-keyring"
       prerelease: ${{ inputs.prerelease }}
     secrets: inherit
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore binaries
 /bin
+/dist
 
 # Generated go-test coverage reports
 coverprofiles/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+version: 2
+
+project_name: pinentry-keyring
+
+env:
+  - CGO_ENABLED=0
+
+builds:
+  - binary: pinentry-keyring
+    main: main.go
+    goos:
+      - linux
+    goarch:
+      - arm64
+      - amd64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s
+
+archives:
+  - formats: ["binary"]
+
+changelog:
+  disable: true
+release:
+  disable: true

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ SHELL := bash
 build:
 	hack/build.sh
 
+# Build all artifacts used for release
+release:
+	hack/release.sh
+
 # Run unit-tests
 test:
 	go test -v -coverprofile=coverprofile.out .
@@ -59,6 +63,7 @@ help:
 
 .PHONY: \
 	build \
+	release \
 	test \
 	update-deps \
 	lint \

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -4,7 +4,7 @@ set -e
 
 base_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath)/.."
 
-folders=("bin" "coverprofiles" "tmp" "x86_64" "aarch64")
+folders=("bin" "dist" "coverprofiles" "tmp" "x86_64" "aarch64")
 files=("coverprofile.out")
 
 for folder in "${folders[@]}"; do

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+
+base_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath | xargs dirname)"
+dist_dir="${base_dir}/dist"
+bin_dir="${base_dir}/bin"
+name="$(yq -r '.project_name' "${base_dir}/.goreleaser.yaml")"
+
+echo "Checking if goreleaser is installed:"
+if command -v goreleaser &>/dev/null; then
+    echo "goreleaser is installed"
+    goreleaser="$(command -v goreleaser)"
+else
+    echo "goreleaser is not installed, downloading latest version..."
+    LATEST="$(curl -sf https://goreleaser.com/static/latest)"
+    [ -e "${bin_dir}" ] || mkdir "${bin_dir}"
+    arch="$(uname -m)"
+    [ "${arch}" != "aarch64" ] || arch="arm64"
+    curl -SL -o "${bin_dir}/goreleaser.tar.gz" "https://github.com/goreleaser/goreleaser/releases/download/${LATEST}/goreleaser_$(uname -s)_${arch}.tar.gz"
+    tar -xzf "${bin_dir}/goreleaser.tar.gz" -C "${bin_dir}" goreleaser
+    rm "${bin_dir}/goreleaser.tar.gz"
+    goreleaser="${bin_dir}/goreleaser"
+fi
+
+echo "Building releaser artifacts with goreleaser"
+${goreleaser} release --skip=announce,archive,publish,validate --clean
+
+echo "Moving release artifacts to top level of dist directory"
+artifacts="$(cat "${dist_dir}/artifacts.json" | jq -r -c '.[]')"
+echo "${artifacts}" | while read -r artifact; do
+    if ! [[ "$(echo "${artifact}" | jq -r '.name')" =~ ^${name}(\.exe)?$ ]]; then
+        continue
+    fi
+
+    path="${base_dir}/$(echo "${artifact}" | jq -r '.path')"
+    goarch="$(echo "${artifact}" | jq -r '.goarch')"
+    ext="$(echo "${artifact}" | jq -r '.extra.Ext')"
+
+    mv "${path}" "${dist_dir}/${name}-${goarch}${ext}"
+
+    path="$(dirname "${path}")"
+    rm -r "${path}"
+done
+
+
+echo "Cleaning up dist directory"
+rm -r "${dist_dir}/artifacts.json" "${dist_dir}/config.yaml" "${dist_dir}/metadata.json"


### PR DESCRIPTION
Instead of a matrix build job, use goreleaser instead.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>